### PR TITLE
Add Telegram Web App frontend

### DIFF
--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,45 @@
+const statusEl = document.getElementById('status');
+const logEl = document.getElementById('log');
+const matchBtn = document.getElementById('matchBtn');
+
+const params = new URLSearchParams(window.location.search);
+const playerId = params.get('player_id') || Math.random().toString(36).slice(2);
+
+function addLog(msg) {
+  const li = document.createElement('li');
+  li.textContent = msg;
+  logEl.appendChild(li);
+}
+
+const ws = new WebSocket(`ws://${window.location.host}/ws/${playerId}`);
+ws.onopen = () => statusEl.textContent = 'Connected';
+ws.onmessage = (event) => {
+  try {
+    const data = JSON.parse(event.data);
+    if (data.event === 'matched') {
+      statusEl.textContent = `Matched with ${data.opponent}`;
+    } else if (data.event === 'message') {
+      addLog(`${data.from}: ${data.data}`);
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};
+ws.onclose = () => statusEl.textContent = 'Disconnected';
+
+matchBtn.addEventListener('click', () => {
+  fetch('/matchmake', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ player_id: playerId })
+  })
+    .then(r => r.json())
+    .then(data => {
+      if (data.status === 'waiting') {
+        statusEl.textContent = 'Waiting for opponent...';
+      } else if (data.status === 'matched') {
+        statusEl.textContent = `Matched with ${data.opponent}`;
+      }
+    })
+    .catch(err => console.error(err));
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Game Lobby</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div class="container">
+    <h1>Game Lobby</h1>
+    <div id="status">Connecting...</div>
+    <button id="matchBtn">Find Match</button>
+    <ul id="log"></ul>
+  </div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -1,0 +1,31 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #f2f2f2;
+}
+
+.container {
+  display: grid;
+  gap: 1rem;
+  width: 300px;
+  text-align: center;
+}
+
+button {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+#log {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  max-height: 200px;
+  overflow-y: auto;
+  border: 1px solid #ccc;
+}

--- a/game.py
+++ b/game.py
@@ -9,6 +9,8 @@ API_TOKEN = '1718355118:AAFkuoOFyJVkVy21CarleBjeaM_3O55G680'
 GAME_SHORT_NAME = "Flop"
 # URL of our FastAPI server with hosted web app
 GAME_URL = "http://localhost:8000/game.html"
+# URL of new frontend for Telegram Web App
+WEB_APP_URL = "http://localhost:8000/frontend/index.html"
 
 bot = Bot(token=API_TOKEN)
 dp = Dispatcher()
@@ -34,6 +36,16 @@ async def process_callback(callback_query: CallbackQuery):
         callback_query.id,
         url=GAME_URL
     )
+
+@dp.message(Command('app'))
+async def send_web_app(message: types.Message):
+    """Send keyboard that opens the frontend as a Telegram Web App."""
+    kb = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [InlineKeyboardButton(text="Open Lobby", web_app=types.WebAppInfo(url=WEB_APP_URL))]
+        ]
+    )
+    await message.answer("Открыть приложение", reply_markup=kb)
 
 async def main():
     await bot.delete_webhook(drop_pending_updates=True)

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Body
 from fastapi.staticfiles import StaticFiles
 from dataclasses import dataclass
 from typing import Dict, Deque
@@ -19,7 +19,7 @@ sessions: Dict[str, Session] = {}
 websockets: Dict[str, WebSocket] = {}
 
 @app.post("/matchmake")
-async def matchmake(player_id: str):
+async def matchmake(player_id: str = Body(..., embed=True)):
     """Put player in queue and pair with opponent if available."""
     if waiting_players:
         opponent = waiting_players.popleft()


### PR DESCRIPTION
## Summary
- create minimal frontend with CSS Grid layout
- connect to FastAPI backend via HTTP and WebSocket
- expose new Web App button in Telegram bot
- accept matchmaking requests via JSON body

## Testing
- `python -m py_compile game.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68445f9baf188331bc8ea79734a70435